### PR TITLE
V2

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,9 +97,12 @@ impl<'a> DeferStack<'a> {
             let ret: &mut DeferCallBack<T, F> = &mut *raw_ptr;
             let deferred = Box::from_raw(raw_ptr);
 
-            (&mut *(self.inner.get() )).push(deferred);
+            (&mut *(self.inner.get())).push(deferred);
 
-            Handle { inner: ret, __nosend: PhantomData }
+            Handle {
+                inner: ret,
+                __nosend: PhantomData,
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -470,4 +470,27 @@ mod tests {
     //         Some(())
     //     });
     // }
+
+    // #[test]
+    // fn test_cell_swap() {
+    //     use std::cell::Cell;
+
+    //     scoped(|guard| {
+    //         let mut v = guard.on_scope_success(vec![1, 2, 3, 4], |v| {});
+
+    //         let mut c1 = Cell::new(guard);
+
+    //         scoped(|evil_guard| {
+    //             let mut c2 = Cell::new(evil_guard);
+
+    //             c2.swap(&c1);
+
+    //             Some(())
+    //         });
+
+    //         v.push(10);
+
+    //         Some(())
+    //     });
+    // }
 }


### PR DESCRIPTION
Fixes https://github.com/DutchGhost/scoped/issues/4:
- Renamed `Deferring` to `DeferStack`
- Default implementations and constructors of the Guard type are removed, because they are unsound to have.
They are unsound, because a new Guard could be created, and swapped with another, potentially invalidating all Handles returned from the Guard.
- The lifetime of the Handle returned by push() is tied to the lifetime of self
- Changed FnMut to FnOnce

Fixes https://github.com/DutchGhost/scoped/issues/5

Fixes https://github.com/DutchGhost/scoped/issues/6